### PR TITLE
Improve accuracy of location updates and add a usable error estimate in OfflineProvider

### DIFF
--- a/src/org/openbmap/unifiedNlp/Geocoder/AbstractProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/AbstractProvider.java
@@ -18,6 +18,7 @@
 package org.openbmap.unifiedNlp.Geocoder;
 
 import android.location.Location;
+import android.net.wifi.ScanResult;
 import android.util.Log;
 
 import org.openbmap.unifiedNlp.services.Cell;
@@ -31,7 +32,7 @@ public abstract class AbstractProvider implements ILocationProvider {
     private Location mLastLocation;
     private Long mLastFix;
 
-    public abstract void getLocation(ArrayList<String> wifiList, List<Cell> cellsList);
+    public abstract void getLocation(List<ScanResult> wifiList, List<Cell> cellsList);
 
     /**
      * Returns last location update

--- a/src/org/openbmap/unifiedNlp/Geocoder/ILocationProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/ILocationProvider.java
@@ -19,9 +19,11 @@ package org.openbmap.unifiedNlp.Geocoder;
 
 import org.openbmap.unifiedNlp.services.Cell;
 
+import android.net.wifi.ScanResult;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public interface ILocationProvider {
-    public void getLocation(ArrayList<String> wifiList, List<Cell> cellsList);
+    public void getLocation(List<ScanResult> wifiList, List<Cell> cellsList);
 }

--- a/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
@@ -32,10 +32,13 @@ import android.os.Bundle;
 import android.os.SystemClock;
 import android.preference.PreferenceManager;
 import android.util.Log;
+
 import org.openbmap.unifiedNlp.Preferences;
 import org.openbmap.unifiedNlp.services.Cell;
+
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
@@ -172,7 +175,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                     	result.setAccuracy(DEFAULT_WIFI_ACCURACY);
                         Bundle b = new Bundle();
                         b.putString("source", "wifis");
-                        b.putStringArray("bssids", wifiQueryArgs);
+                        b.putStringArrayList("bssids", new ArrayList<String>(Arrays.asList(wifiQueryArgs)));
                         result.setExtras(b);
                         state = WIFIS_MATCH;
                         return result;
@@ -249,7 +252,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                     	result.setAccuracy((float) Math.sqrt(result.getAccuracy()));
                         Bundle b = new Bundle();
                         b.putString("source", "wifis");
-                        b.putStringArray("bssids", wifiQueryArgs);
+                        b.putStringArrayList("bssids", new ArrayList<String>(Arrays.asList(wifiQueryArgs)));
                         result.setExtras(b);
                         state = WIFIS_MATCH;
                         return result;

--- a/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
@@ -174,8 +174,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                     } else if (wifiResults.length == 1) {
                     	// We have just one location, pass it
                     	result = wifiLocations.get(wifiResults[0]);
-                    	// FIXME DEFAULT_WIFI_ACCURACY is way too optimistic IMHO
-                    	result.setAccuracy(DEFAULT_WIFI_ACCURACY);
+                    	result.setAccuracy(getWifiRxDist(wifiList.get(wifiResults[0]).level) / 10);
                         Bundle b = new Bundle();
                         b.putString("source", "wifis");
                         b.putStringArrayList("bssids", new ArrayList<String>(Arrays.asList(wifiQueryArgs)));

--- a/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
@@ -121,7 +121,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                 				// determine age (elapsedRealtime is in milliseconds, timestamp is in microseconds)
                 				long age = SystemClock.elapsedRealtime() - (r.timestamp / 1000);
-                				if (age >= 5000)
+                				if (age >= 2000)
                 					Log.w(TAG, String.format("wifi %s is stale (%d ms), using it anyway", r.BSSID, age));
                 			}
                 			// wifi is OK to use for geolocation, add it to list

--- a/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
@@ -110,6 +110,10 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                 if (wifiListRaw != null) {
                 	// Generates a list of wifis from scan results
                 	for (ScanResult r : wifiListRaw) {
+                		long age = 0;
+            			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
+            				// determine age (elapsedRealtime is in milliseconds, timestamp is in microseconds)
+            				age = now - (r.timestamp / 1000);
                 		/*
                 		 * Any filtering of scan results can be done here. Examples include:
                 		 * empty or bogus BSSIDs, SSIDs with "_nomap" suffix, blacklisted wifis
@@ -119,12 +123,8 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                 		else if (r.SSID.endsWith("_nomap")) {
                 			// BSSID with _nomap suffix, user does not want it to be mapped or used for geolocation
                 		} else
-                			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                				// determine age (elapsedRealtime is in milliseconds, timestamp is in microseconds)
-                				long age = now - (r.timestamp / 1000);
-                				if (age >= 2000)
-                					Log.w(TAG, String.format("wifi %s is stale (%d ms), using it anyway", r.BSSID, age));
-                			}
+                			if (age >= 2000)
+                				Log.w(TAG, String.format("wifi %s is stale (%d ms), using it anyway", r.BSSID, age));
                 			// wifi is OK to use for geolocation, add it to list
                 			wifiList.put(r.BSSID.replace(":", "").toUpperCase(), r);
                 	}

--- a/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
@@ -303,9 +303,9 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                   			
                     		// RSSI-based distance
                     		float rxdist =
-                    				(resultIds[i].contains("|")) ?
+                    				(wifiList.get(resultIds[i]) == null) ?
                     						DEFAULT_CELL_ACCURACY * 10 :
-                    							getWifiRxDist(wifiList.get(resultIds[i]).level) ;
+                    							getWifiRxDist(wifiList.get(resultIds[i]).level);
                     		
                 			// distance penalty for stale wifis (supported only on Jellybean MR1 and higher)
                     		// for cells this value is always zero (cell scans are always current)
@@ -326,7 +326,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                     					distResults);
                     			
                     			// subtract distance between device and each transmitter to get "disagreement"
-                    			if (resultIds[j].contains("|"))
+                    			if (wifiList.get(resultIds[j]) == null)
                     				distResults[0] -= rxdist + DEFAULT_CELL_ACCURACY * 10;
                     			else {
                     				distResults[0] -= rxdist + getWifiRxDist(wifiList.get(resultIds[j]).level);

--- a/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
@@ -335,6 +335,8 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                     		// correct distance from transmitter to a realistic value
                     		rxdist /= 10;
                     		
+            				Log.v(TAG, String.format("%s: disagreement = %.5f, rxdist = %.5f, age = %d ms, ageBasedDist = %.5f", resultIds[i], Math.sqrt(locations.get(resultIds[i]).getAccuracy()), rxdist, now - (wifiList.get(resultIds[i]).timestamp / 1000), ageBasedDist));
+                      		
                     		// add additional error sources: RSSI-based (distance from transmitter) and age-based (distance traveled since)
                       		locations.get(resultIds[i]).setAccuracy(locations.get(resultIds[i]).getAccuracy() + rxdist * rxdist + ageBasedDist * ageBasedDist);
                       		

--- a/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
@@ -352,7 +352,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                     		}
                     		locations.get(resultIds[i]).setAccuracy(locations.get(resultIds[i]).getAccuracy() / (resultIds.length - 1));
                     		// correct distance from transmitter to a realistic value
-                    		rxdist /= 10;
+                    		rxdist /= 7;
                     		
             				Log.v(TAG, String.format("%s: disagreement = %.5f, rxdist = %.5f, age = %d ms, ageBasedDist = %.5f", resultIds[i], Math.sqrt(locations.get(resultIds[i]).getAccuracy()), rxdist, now - (wifiList.get(resultIds[i]).timestamp / 1000), ageBasedDist));
                       		

--- a/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
@@ -354,7 +354,12 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                     		// correct distance from transmitter to a realistic value
                     		rxdist /= 7;
                     		
-            				Log.v(TAG, String.format("%s: disagreement = %.5f, rxdist = %.5f, age = %d ms, ageBasedDist = %.5f", resultIds[i], Math.sqrt(locations.get(resultIds[i]).getAccuracy()), rxdist, now - (wifiList.get(resultIds[i]).timestamp / 1000), ageBasedDist));
+            				Log.v(TAG, String.format("%s: disagreement = %.5f, rxdist = %.5f, age = %d ms, ageBasedDist = %.5f",
+            						resultIds[i],
+            						Math.sqrt(locations.get(resultIds[i]).getAccuracy()),
+            						rxdist,
+            						(wifiList.get(resultIds[i]) != null) ? (now - (wifiList.get(resultIds[i]).timestamp / 1000)) : 0,
+            						ageBasedDist));
                       		
                     		// add additional error sources: RSSI-based (distance from transmitter) and age-based (distance traveled since)
                       		locations.get(resultIds[i]).setAccuracy(locations.get(resultIds[i]).getAccuracy() + rxdist * rxdist + ageBasedDist * ageBasedDist);

--- a/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
@@ -428,7 +428,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
     private static float getWifiRxDist(int rxlev) {
     	final int refRxlev = -100;
     	final float refDist = 1000.0f;
-    	float factor = (float) Math.pow(2, 6 / (refRxlev - rxlev));
+    	float factor = (float) Math.pow(2.0f, 6.0f / (refRxlev - rxlev));
     	return refDist * factor;
     }
 

--- a/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
@@ -92,6 +92,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
 			@SuppressLint("DefaultLocale")
             @Override
             protected Location doInBackground(LocationQueryParams... params) {
+            	long now = SystemClock.elapsedRealtime();
                 if (params == null) {
                     throw new IllegalArgumentException("Wifi list was null");
                 }
@@ -120,7 +121,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                 		} else
                 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                 				// determine age (elapsedRealtime is in milliseconds, timestamp is in microseconds)
-                				long age = SystemClock.elapsedRealtime() - (r.timestamp / 1000);
+                				long age = now - (r.timestamp / 1000);
                 				if (age >= 2000)
                 					Log.w(TAG, String.format("wifi %s is stale (%d ms), using it anyway", r.BSSID, age));
                 			}
@@ -292,7 +293,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                     		// penalize stale entries (wifis only, supported only on Jellybean MR1 and higher)
                       		if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) && !resultIds[i].contains("|")) {
                 				// elapsedRealtime is in milliseconds, timestamp is in microseconds
-                				ageBasedDist = (SystemClock.elapsedRealtime() - (wifiList.get(resultIds[i]).timestamp / 1000)) * speed;
+                				ageBasedDist = (now - (wifiList.get(resultIds[i]).timestamp / 1000)) * speed;
                 			}
 
                     		for (int j = i + 1; j < resultIds.length; j++) {
@@ -310,7 +311,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                     			else {
                     				distResults[0] -= rxdist + getWifiRxDist(wifiList.get(resultIds[j]).level);
                               		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
-                        				jAgeBasedDist = (SystemClock.elapsedRealtime() - (wifiList.get(resultIds[j]).timestamp / 1000)) * speed;
+                        				jAgeBasedDist = (now - (wifiList.get(resultIds[j]).timestamp / 1000)) * speed;
                     			}
                     			
                     			/*

--- a/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
@@ -122,11 +122,12 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                 			Log.w(TAG, "skipping wifi with empty BSSID");
                 		else if (r.SSID.endsWith("_nomap")) {
                 			// BSSID with _nomap suffix, user does not want it to be mapped or used for geolocation
-                		} else
+                		} else {
                 			if (age >= 2000)
                 				Log.w(TAG, String.format("wifi %s is stale (%d ms), using it anyway", r.BSSID, age));
                 			// wifi is OK to use for geolocation, add it to list
                 			wifiList.put(r.BSSID.replace(":", "").toUpperCase(), r);
+                		}
                 	}
                 	Log.i(TAG, "Using " + wifiList.size() + " wifis for geolocation");
                 } else

--- a/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
@@ -214,7 +214,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                 				location.setTime(System.currentTimeMillis());
                 				Bundle b = new Bundle();
                 				b.putString("source", "cells");
-                				//b.putString("bssid", c.getString(2)); // TODO put cell ID
+                				b.putString("cell", c.getInt(2) + "|" + c.getInt(3) + "|" + c.getInt(4) + "|" + c.getInt(5));
                 				location.setExtras(b);
                 				locations.put(c.getInt(2) + "|" + c.getInt(3) + "|" + c.getInt(4) + "|" + c.getInt(5), location);
                 				state |= CELLS_MATCH;

--- a/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
@@ -294,7 +294,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                     		// penalize stale entries (wifis only, supported only on Jellybean MR1 and higher)
                       		if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) && !resultIds[i].contains("|")) {
                 				// elapsedRealtime is in milliseconds, timestamp is in microseconds
-                				ageBasedDist = (now - (wifiList.get(resultIds[i]).timestamp / 1000)) * speed;
+                				ageBasedDist = (now - (wifiList.get(resultIds[i]).timestamp / 1000)) * speed / 1000;
                 			}
 
                     		for (int j = i + 1; j < resultIds.length; j++) {
@@ -312,7 +312,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                     			else {
                     				distResults[0] -= rxdist + getWifiRxDist(wifiList.get(resultIds[j]).level);
                               		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
-                        				jAgeBasedDist = (now - (wifiList.get(resultIds[j]).timestamp / 1000)) * speed;
+                        				jAgeBasedDist = (now - (wifiList.get(resultIds[j]).timestamp / 1000)) * speed / 1000;
                     			}
                     			
                     			/*

--- a/src/org/openbmap/unifiedNlp/Geocoder/OnlineProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/OnlineProvider.java
@@ -19,6 +19,7 @@ package org.openbmap.unifiedNlp.Geocoder;
 
 import android.content.Context;
 import android.location.Location;
+import android.net.wifi.ScanResult;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
@@ -79,7 +80,20 @@ public class OnlineProvider extends AbstractProvider implements ILocationProvide
      */
     @SuppressWarnings("unchecked")
     @Override
-    public void getLocation(ArrayList<String> wifisList, List<Cell> cellsList) {
+    public void getLocation(List<ScanResult> wifisList, List<Cell> cellsList) {
+        ArrayList<String> wifis = new ArrayList<String>();
+
+        if (wifisList != null) {
+            // Generates a list of wifis from scan results
+            for (ScanResult r : wifisList) {
+                if ((r.BSSID != null) & !(r.SSID.endsWith("_nomap"))) {
+                    wifis.add(r.BSSID);
+                }
+            }
+            Log.i(TAG, "Using " + wifis.size() + " wifis for geolocation");
+        } else
+            Log.i(TAG, "No wifis supplied for geolocation");
+        
         new AsyncTask<Object, Void, JSONObject>() {
 
             @Override
@@ -186,6 +200,6 @@ public class OnlineProvider extends AbstractProvider implements ILocationProvide
                 Log.v(TAG, "Query param: " + root.toString());
                 return root;
             }
-        }.execute(wifisList, cellsList);
+        }.execute(wifis, cellsList);
     }
 }

--- a/src/org/openbmap/unifiedNlp/services/OpenbmapNlpService.java
+++ b/src/org/openbmap/unifiedNlp/services/OpenbmapNlpService.java
@@ -215,22 +215,13 @@ public class OpenbmapNlpService extends LocationBackendService implements ILocat
                         //Log.d(TAG, "Wifi results are available now.");
 
                         if (scanning) {
+                        	// TODO pass wifi signal strength to geocoder
                             //Log.i(TAG, "Wifi scan results arrived..");
                             List<ScanResult> scans = wifiManager.getScanResults();
-                            ArrayList<String> wifis = new ArrayList<String>();
-
-                            if (scans != null) {
-                                // Generates a list of wifis from scan results
-                                for (ScanResult r : scans) {
-                                    if ((r.BSSID != null) & !(r.SSID.endsWith("_nomap"))) {
-                                        wifis.add(r.BSSID);
-                                    }
-                                }
-                                Log.i(TAG, "Using " + wifis.size() + " wifis for geolocation");
-                            } else {
+                            
+                            if (scans == null)
                                 // @see http://code.google.com/p/android/issues/detail?id=19078
-                                Log.e(TAG, "WifiManager.getScanResults returned null");
-                            }
+                            	Log.e(TAG, "WifiManager.getScanResults returned null");
 
                             if (System.currentTimeMillis() - queryTime > REFRESH_INTERVAL || queryTime == 0) {
                                 Log.d(TAG, "Scanning wifis & cells");
@@ -243,7 +234,7 @@ public class OpenbmapNlpService extends LocationBackendService implements ILocat
                                 }
 
                                 if (mGeocoder != null) {
-                                    mGeocoder.getLocation(wifis, cells);
+                                    mGeocoder.getLocation(scans, cells);
                                 } else {
                                     Log.e(TAG, "Geocoder is null!");
                                 }
@@ -262,7 +253,7 @@ public class OpenbmapNlpService extends LocationBackendService implements ILocat
                 queryTime = System.currentTimeMillis();
                 List<Cell> cells = getCells();
                 if (mGeocoder != null) {
-                    mGeocoder.getLocation(new ArrayList<String>(), cells);
+                    mGeocoder.getLocation(null, cells);
                 } else {
                     Log.e(TAG, "Geocoder is null!");
                 }


### PR DESCRIPTION
Improvements:

* Introduces a usable error estimate for the location derived from each transmitter, based on transmitter-receiver distance, age of scan result and distance from other transmitters
* Individual locations are fused using a simplified Kálmán filter, giving more weight to more accurate locations
* Both cells and wifis are used for distance comparisons and to determine final location
* All visible cells with full ID are considered for location updates

Notes:

Using multiple cells for geolocation works only where the full cell ID is available. On 3G/4G, the full ID is only available for the serving cell (for neighboring cells only the PSC/PCI is available until the device connects to that cell). On multi-SIM devices, where there is one serving cell per SIM slot, all cells can be used if they are exposed through the Android API. Note that some devices never report any neighboring cells.

When the reported accuracy is low (several hundred meters or more), this is typically the result of a moved wifi: Suppose the device is picking up n wifis, of which one has moved. This will dramatically increase the error estimate for each location – the outlier will get an error close to the actual distance from the others, while all the others will get 1/n times that distance as an error. The synthesized location will have an error which is slightly lower than 1/n times the distance the one wifi has moved. All of this can be observed in the logs. The location reported will generally be only slightly off (much closer to the actual location than it was previously). The more stationary wifis there are in view, the better the result will be. A possible future improvement could be to identify obvious outliers and ignore them.

Blacklisting is not yet implemented – I had a look at the mechanisms in Radiobeacon today and they're somewhat complex. That will be a future extension – though the current code already provides for some generic filtering (basically a series of `if` statements) which can easily be extended to filter for other criteria.