### PR TITLE
More accuracy-related improvements

### DIFF
--- a/src/org/openbmap/services/wireless/blacklists/SsidBlackList.java
+++ b/src/org/openbmap/services/wireless/blacklists/SsidBlackList.java
@@ -1,0 +1,182 @@
+/*
+	Radiobeacon - Openbmap wifi and cell logger
+    Copyright (C) 2013  wish7
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.openbmap.services.wireless.blacklists;
+
+import android.annotation.SuppressLint;
+import android.util.Log;
+
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+import org.xmlpull.v1.XmlPullParserFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+
+/**
+ * Validates ssid against xml file of black listed wifis (e.g. mobile wlans on buses, trains, etc)
+ */
+public class SsidBlackList {
+
+	private static final String	TAG	= SsidBlackList.class.getSimpleName();
+	
+	/**
+	 * Debug setting: re-create XML file on each run (ergo: refreshing the list)
+	 * This is helpful while adding new mac addresses to BssidBlackListBootstraper
+	 * When no mac addresses are added to BssidBlackListBootstraper anymore,
+	 * ALWAYS_RECREATE_BSSID_BLACKLIST can be set to false
+	 */
+	private static final boolean ALWAYS_RECREATE_SSID_BLACKLIST	= true;
+	
+	/**
+	 * XML tag prefixes
+	 */
+	private static final String	PREFIX_TAG	= "prefix";
+
+	/**
+	 * XML tag suffixes
+	 */
+	private static final String	SUFFIX_TAG	= "suffix";
+	
+	/**
+	 * List of ignored ssid prefixes
+	 */
+	private final ArrayList<String>	mPrefixes;
+	
+	/**
+	 * List of ignored ssid suffixes
+	 */
+	private final ArrayList<String>	mSuffixes;
+
+	public SsidBlackList() {
+		mPrefixes = new ArrayList<>();
+		mSuffixes = new ArrayList<>();
+	}
+
+	/**
+	 * Loads blacklist from xml files
+	 * @param defaultList - generic list (well-known bad wifis, e.g. trains, buses, mobile hotspots)
+	 * @param extraUserList - user-provided list (e.g. own wifi)
+	 * @throws XmlPullParserException
+	 */
+	public final void openFile(final String defaultList, final String extraUserList) {
+
+		if (ALWAYS_RECREATE_SSID_BLACKLIST) {
+			SsidBlackListBootstraper.run(defaultList);
+		}
+		
+		if (defaultList != null) {
+			try {				
+				final File file = new File(defaultList);
+				final FileInputStream defaultStream = new FileInputStream(file);
+				add(defaultStream);
+			} catch (final FileNotFoundException e) {
+				Log.i(TAG, "Default blacklist " + defaultList + " not found. Setting up..");
+				SsidBlackListBootstraper.run(defaultList);
+			} 
+		}
+
+		if (extraUserList != null) {
+			try {
+				final File file = new File(extraUserList);
+				final FileInputStream userStream = new FileInputStream(file);
+				add(userStream);
+			} catch (final FileNotFoundException e) {
+				Log.w(TAG, "User-defined blacklist " + extraUserList + " not found. Skipping");
+			} 
+		} else {
+			Log.i(TAG, "No user-defined blacklist provided");
+		}
+	}
+
+	/**
+	 * @param file
+	 */
+	private void add(final FileInputStream file) {
+		try {
+			final XmlPullParserFactory factory = XmlPullParserFactory.newInstance();
+			factory.setNamespaceAware(true);
+			final XmlPullParser xpp = factory.newPullParser();
+
+			if (file != null) {
+				xpp.setInput(new InputStreamReader(file));
+
+				int eventType = xpp.getEventType();
+				String currentTag = null;
+				String value = null;
+
+				while (eventType != XmlPullParser.END_DOCUMENT) {
+					if (eventType == XmlPullParser.START_TAG) {
+						currentTag = xpp.getName();
+					} else if (eventType == XmlPullParser.TEXT) {
+						if (PREFIX_TAG.equals(currentTag) || SUFFIX_TAG.equals(currentTag)) {
+							value = xpp.getText();
+						}
+					} else if (eventType == XmlPullParser.END_TAG) {
+						if (PREFIX_TAG.equals(xpp.getName())) {
+							mPrefixes.add(value);
+						}
+						if (SUFFIX_TAG.equals(xpp.getName())) {
+							mSuffixes.add(value);
+						}
+					}
+					eventType = xpp.next();
+				}
+			}
+		} catch (final IOException e) {
+			Log.e(TAG, "I/O exception reading blacklist");
+		} catch (final XmlPullParserException e) {
+			Log.e(TAG, "Error parsing blacklist");
+		}
+		Log.i(TAG, "Loaded " + (mPrefixes.size() + mSuffixes.size()) + " SSID blacklist entries");
+	}
+
+	/**
+	 * Checks whether given ssid is in ignore list
+	 * @param ssid SSID to check
+	 * @return true, if in ignore list
+	 */
+	@SuppressLint("DefaultLocale")
+	public final boolean contains(final String ssid) {
+		boolean match = false;
+		for (final String prefix : mPrefixes) {
+			if (ssid.toLowerCase().startsWith(prefix.toLowerCase())) {
+				match = true; 
+				break;
+			}
+		}
+
+		// don't look anyfurther
+		if (match) {
+			return match;
+		}
+		
+		for (final String suffix : mSuffixes) {
+			if (ssid.toLowerCase().endsWith(suffix.toLowerCase())) {
+				match = true;
+				break;
+			}
+		}
+
+		return match; // OK
+	}
+}

--- a/src/org/openbmap/services/wireless/blacklists/SsidBlackListBootstraper.java
+++ b/src/org/openbmap/services/wireless/blacklists/SsidBlackListBootstraper.java
@@ -1,0 +1,257 @@
+/*
+Radiobeacon - Openbmap wifi and cell logger
+    Copyright (C) 2013  wish7
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+package org.openbmap.services.wireless.blacklists;
+
+import android.util.Log;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+/**
+ * Creates initial wifi blacklist with some default entries
+ */
+public final class SsidBlackListBootstraper {
+
+	private static final String TAG= SsidBlackListBootstraper.class.getSimpleName();
+
+	/**
+	 * XML opening tag prefix
+	 */
+	private static final String PREFIX_OPEN= "<prefix comment=\"";
+
+	/**
+	 * XML middle tag prefix
+	 */
+	private static final String PREFIX_MIDDLE = "\">";
+
+	/**
+	 * XML closing tag prefix
+	 */
+	private static final String PREFIX_CLOSE = "</prefix>";
+
+	/**
+	 * XML opening tag prefix
+	 */
+	private static final String SUFFIX_OPEN= "<suffix comment=\"";
+
+	/**
+	 * XML middle tag prefix
+	 */
+	private static final String SUFFIX_MIDDLE = "\">";
+
+	/**
+	 * XML closing tag prefix
+	 */
+	private static final String SUFFIX_CLOSE = "</suffix>";
+
+	/**
+	 * 
+	 */
+	private static final String START_TAG= "<ignorelist>";
+
+	/**
+	 * 
+	 */
+	private static final String END_TAG= "</ignorelist>";
+
+	private static final String[][] PREFIXES = {
+		{"default", "ASUS"},
+		{"default", "Android Barnacle Wifi Tether"},
+		{"default", "AndroidAP"},
+		{"default", "AndroidTether"},
+		{"default", "blackberry mobile hotspot"},
+		{"default", "Clear Spot"},
+		{"default", "ClearSpot"},
+		{"default", "docomo"},
+		{"Maintenance network on German ICE trains", "dr_I)p"},	
+		{"default", "Galaxy Note"},
+		{"default", "Galaxy S"},
+		{"default", "Galaxy Tab"},
+		{"default", "HelloMoto"},
+		{"default", "HTC "},
+		{"default", "iDockUSA"},
+		{"default", "iHub_"},
+		{"default", "iPad"},
+		{"default", "ipad"},
+		{"default", "iPhone"},
+		{"default", "LG VS910 4G"},
+		{"default", "MIFI"},
+		{"default", "MiFi"},
+		{"default", "mifi"},
+		{"default", "MOBILE"},
+		{"default", "Mobile"},
+		{"default", "mobile"},
+		{"default", "myLGNet"},
+		{"default", "myTouch 4G Hotspot"},
+		{"default", "PhoneAP"},
+		{"default", "SAMSUNG"},
+		{"default", "Samsung"},
+		{"default", "Sprint"},
+		{"Long haul buses", "megabus-wifi"},
+		{"German long haul buses", "DeinBus"},
+		{"German long haul buses", "MeinFernbus"},
+		{"German long haul buses", "adac_postbus"},
+		{"German long haul buses", "flixbus"},
+		{"Long haul buses", "eurolines"},	
+		{"Long haul buses", "ecolines"},
+		{"Hurtigen lines", "guest@MS"},
+		{"Hurtigen lines", "admin@MS"},
+		{"German fast trains", "Telekom_ICE"},
+		{"European fast trains", "thalysnet"},
+		{"default", "Trimble "},
+		{"default", "Verizon"},
+		{"default", "VirginMobile"},
+		{"default", "VTA Free Wi-Fi"},
+		{"default", "webOS Network"},
+		{"GoPro cams", "goprohero3"},
+		{"Swiss Post Auto Wifi", "PostAuto"},
+		{"Swiss Post Auto Wifi French", "CarPostal"},
+		{"Swiss Post Auto Wifi Italian", "AutoPostale"},
+		
+		// mobile hotspots
+		{"German 1und1 mobile hotspots", "1und1 mobile"},
+		{"xperia tablet", "xperia tablet"},
+        {"Sony devices", "XPERIA"},
+		{"xperia tablet", "androidhotspot"},
+        {"HP laptops", "HP envy"},
+		{"empty ssid (not really hidden, just not broadcasting..)", ""},
+
+
+		// some ssids from our friends at https://github.com/dougt/MozStumbler
+		{"default", "ac_transit_wifi_bus"},
+		{"Nazareen express transportation services (Israel)", "Afifi"},
+		{"Oslo airport express train on-train WiFi (Norway)","AirportExpressZone"}, 
+		{"default", "AmtrakConnect"},
+		{"default", "amtrak_"},
+		{"Arriva Nederland on-train Wifi (Netherlands)", "arriva"}, 
+		{"Arcticbus on-bus WiFi (Sweden)","Arcticbus Wifi"},
+		{"Swiss municipial busses on-bus WiFi (Italian speaking part)","AutoPostale"},
+		{"Barcelona tourisitic buses http://barcelonabusturistic.cat","Barcelona Bus Turistic "},
+		{"Tromso on-boat (and probably bus) WiFi (Norway)"	,"Boreal_Kundenett"},
+		{"Bus4You on-bus WiFi (Norway)","Bus4You-"},
+		{"Capital Bus on-bus WiFi (Taiwan)", "CapitalBus"}, 
+		{"Swiss municipial busses on-bus WiFi (French speaking part)" ,"CarPostal"},
+		{"Ceske drahy (Czech railways)", "CDWiFi"},
+		{"Copenhagen S-Tog on-train WiFi: http://www.dsb.dk/s-tog/kampagner/fri-internet-i-s-tog" ,"CommuteNet"},
+		{"CSAD Plzen","csadplzen_bus"},
+		{"Egged transportation services (Israel)", "egged.co.il"}, 
+		{"Empresa municipal de transportes de Madrid","EMT-Madrid"}, 
+		{"First Bus wifi (United Kingdom)","first-wifi"},
+		{"Oslo airport transportation on-bus WiFi (Norway)" ,"Flybussekspressen"},
+		{"Airport transportation on-bus WiFi all over Norway (Norway)" ,"Flybussen"},
+		{"Flygbussarna.se on-bus WiFi (Sweden)"	,"Flygbussarna Free WiFi"},
+		{"GB Tours transportation services (Israel)", "gb-tours.com"},
+		{"default", "GBUS"},
+		{"default", "GBusWifi"},
+		{"Gogo in-flight WiFi", "gogoinflight"},
+		{"Koleje Slaskie transportation services (Poland)" ,"Hot-Spot-KS"},
+		{"ISRAEL-RAILWAYS","ISRAEL-RAILWAYS"},
+		{"Stavanger public transport on-boat WiFi (Norway)"	,"Kolumbus"},
+		{"Kystbussen on-bus WiFi (Norway)" ,"Kystbussen_Kundennett"},
+		{"Hungarian State Railways onboard hotspot on InterCity trains (Hungary)", "MAVSTART-WiFi"}, 
+		{"Nateev Express transportation services (Israel)"	,"Nateev-WiFi"},
+		{"National Express on-bus WiFi (United Kingdom)" ,"NationalExpress"},
+		{"Norgesbuss on-bus WiFi (Norway)"	,"Norgesbuss"},
+		{"Norwegian in-flight WiFi (Norway)" ,"Norwegian Internet Access"},
+		{"NSB on-train WiFi (Norway)"	,"NSB_INTERAKTIV"},
+		{"Omnibus transportation services (Israel)", "Omni-WiFi"},
+		{"OnniBus.com Oy on-bus WiFi (Finland)"	,"onnibus.com"},
+		 {"Oxford Tube on-bus WiFi (United Kindom)" ,"Oxford Tube"},
+		 {"Swiss municipial busses on-bus WiFi (German speaking part)" ,"PostAuto"},
+		{"Qbuzz on-bus WiFi (Netherlands)", "QbuzzWIFI"},
+		{"default", "SF Shuttle Wireless"},
+		{"default", "ShuttleWiFi"},
+		
+		{"Southwest Airlines in-flight WiFi",  "Southwest WiFi"},
+		{"default", "SST-PR-1"}, // Sears Home Service van hotspot?!
+		{"Stagecoach on-bus WiFi (United Kingdom)" ,"stagecoach-wifi"},
+		 
+		{"Taipei City on-bus WiFi (Taiwan)", "TPE-Free Bus"},
+		{"Taiwan High Speed Rail on-train WiFi", "THSR-VeeTIME"},
+		{"Triangle Transit on-bus WiFi"	,"TriangleTransitWiFi_"},
+		{"Nederlandse Spoorwegen on-train WiFi by T-Mobile (Netherlands)", "tmobile"},
+		{"Triangle Transit on-bus WiFi","TriangleTransitWiFi_"}, 
+		{"VR on-train WiFi (Finland)", "VR-junaverkko"},
+		{"Boreal on-bus WiFi (Norway)" ,"wifi@boreal.no"},
+		{"Nettbuss on-bus WiFi (Norway)", "wifi@nettbuss.no"},
+		{"BART", "wifi_rail"}
+	};
+
+	private static final String[][] SUFFIXES = {
+		{"default", "MacBook"},
+		{"default", "MacBook Pro"},
+		{"default", "MiFi"},
+		{"default", "MyWi"},
+		{"default", "Tether"},
+		{"default", "iPad"},
+		{"default", "iPhone"},
+		{"default", "ipad"},
+		{"default", "iphone"},
+		{"default", "tether"},
+		{"default", "adhoc"},
+		{"Google's SSID opt-out", "_nomap"}
+	};
+
+
+
+	public static void run(final String filename) {
+		final File folder = new File(filename.substring(1, filename.lastIndexOf(File.separator)));
+		boolean folderAccessible = false;
+		if (folder.exists() && folder.canWrite()) {
+			folderAccessible = true;
+		}
+
+		if (!folder.exists()) {
+			Log.i(TAG, "Folder missing: create " + folder.getAbsolutePath());
+			folderAccessible = folder.mkdirs();
+		}
+
+		if (folderAccessible) {
+			final StringBuilder sb = new StringBuilder();
+			sb.append(START_TAG);
+			for (final String[] prefix : PREFIXES) {
+				sb.append(PREFIX_OPEN + prefix[0] + PREFIX_MIDDLE + prefix[1] + PREFIX_CLOSE);
+			}
+
+			for (final String[] suffix : SUFFIXES) {
+				sb.append(SUFFIX_OPEN + suffix[0] + SUFFIX_MIDDLE + suffix[1] + SUFFIX_CLOSE);
+			}
+			sb.append(END_TAG);
+
+			try {
+				final File file = new File(filename);
+				final BufferedWriter bw = new BufferedWriter(new FileWriter(file.getAbsoluteFile()));
+				bw.append(sb);
+				bw.close();
+				Log.i(TAG, "Created default blacklist, " + PREFIXES.length + SUFFIXES.length + " entries");
+			} catch (final IOException e) {
+				Log.e(TAG, "Error writing blacklist");
+			} 
+		} else {
+			Log.e(TAG, "Folder not accessible: can't write blacklist");
+		}
+
+	}
+
+	private SsidBlackListBootstraper() {
+	}
+}

--- a/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
@@ -49,6 +49,8 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
     public static final int DEFAULT_WIFI_ACCURACY = 30;
     // Default accuracy for cell results (in meter)
     public static final int DEFAULT_CELL_ACCURACY = 3000;
+    // Assumed ratio between maximum and typical range
+    public static final int TYPICAL_RANGE_FACTOR = 7;
     private static final String TAG = OfflineProvider.class.getName();
     private ILocationCallback mListener;
 
@@ -315,7 +317,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                     		// RSSI-based distance
                     		float rxdist =
                     				(wifiList.get(resultIds[i]) == null) ?
-                    						DEFAULT_CELL_ACCURACY * 10 :
+                    						DEFAULT_CELL_ACCURACY * TYPICAL_RANGE_FACTOR :
                     							getWifiRxDist(wifiList.get(resultIds[i]).level);
                     		
                 			// distance penalty for stale wifis (supported only on Jellybean MR1 and higher)
@@ -338,7 +340,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                     			
                     			// subtract distance between device and each transmitter to get "disagreement"
                     			if (wifiList.get(resultIds[j]) == null)
-                    				distResults[0] -= rxdist + DEFAULT_CELL_ACCURACY * 10;
+                    				distResults[0] -= rxdist + DEFAULT_CELL_ACCURACY * TYPICAL_RANGE_FACTOR;
                     			else {
                     				distResults[0] -= rxdist + getWifiRxDist(wifiList.get(resultIds[j]).level);
                               		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
@@ -363,7 +365,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                     		}
                     		locations.get(resultIds[i]).setAccuracy(locations.get(resultIds[i]).getAccuracy() / (resultIds.length - 1));
                     		// correct distance from transmitter to a realistic value
-                    		rxdist /= 7;
+                    		rxdist /= TYPICAL_RANGE_FACTOR;
                     		
             				Log.v(TAG, String.format("%s: disagreement = %.5f, rxdist = %.5f, age = %d ms, ageBasedDist = %.5f",
             						resultIds[i],

--- a/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
@@ -181,7 +181,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                     state |= EMPTY_CELLS_QUERY;
                 }
 
-                if ((state & (EMPTY_WIFIS_QUERY | EMPTY_CELLS_QUERY)) == 0) {
+                if ((state & (EMPTY_WIFIS_QUERY | EMPTY_CELLS_QUERY)) != (EMPTY_WIFIS_QUERY | EMPTY_CELLS_QUERY)) {
                 	Cursor c;
                 	
                 	if ((state & EMPTY_WIFIS_QUERY) == 0) {

--- a/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
@@ -189,6 +189,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                 		//Log.d(TAG, sql);
 
                 		c = mCatalog.rawQuery(wifiSql, wifiQueryArgs);
+                		Log.i(TAG, String.format("Found %d known wifis", c.getCount()));
                 		for (c.moveToFirst(); !c.isAfterLast(); c.moveToNext()) {
                 			Location location = new Location(TAG);
                 			location.setLatitude(c.getDouble(0));
@@ -206,7 +207,6 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
 
                 		if ((state & WIFIS_MATCH) != WIFIS_MATCH) {
                 			state |= WIFIS_NOT_FOUND;
-                			Log.i(TAG, "No known wifis found");
                 		}
                 	}
                     
@@ -236,7 +236,7 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                 		final String cellSql = "SELECT AVG(latitude), AVG(longitude), mcc, mnc, area, cid FROM cell_zone WHERE " + whereClause + " GROUP BY mcc, mnc, area, cid";
                 		try {
                 			c = mCatalog.rawQuery(cellSql, cellQueryArgs.toArray(new String[0]));
-
+                			Log.i(TAG, String.format("Found %d known cells", c.getCount()));
                 			for (c.moveToFirst(); !c.isAfterLast(); c.moveToNext()) {
                 				Location location = new Location(TAG);
                 				location.setLatitude(c.getDouble(0));
@@ -255,7 +255,6 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
 
                 			if ((state & CELLS_MATCH) != CELLS_MATCH) {
                 				state |= CELLS_NOT_FOUND;
-                				Log.i(TAG, "No known cells found");
                 			}
                 		} catch (SQLiteException e) {
                 			Log.e(TAG, "SQLiteException! Update your database!");

--- a/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
+++ b/src/org/openbmap/unifiedNlp/Geocoder/OfflineProvider.java
@@ -154,7 +154,15 @@ public class OfflineProvider extends AbstractProvider implements ILocationProvid
                 if (cellsListRaw != null) {
                 	for (Cell r : cellsListRaw) {
                 		Log.d(TAG, "Evaluating " + r.toString());
-                		if ((r.mcc <= 0) || (r.mnc <= 0) || (r.area <= 0) || (r.cellId <= 0)) {
+                		/*
+                		 * Filtering of cells happens here. This is typically the case for neighboring
+                		 * cells in UMTS or LTE networks, which are only identified by their PSC or PCI
+                		 * (and are thus useless for lookup). Other filters can be added, such as
+                		 * filtering out cells with bogus data or comparing against a blacklist of
+                		 * "cells on wheels" (whose location can change).
+                		 */
+                		if ((r.mcc <= 0) || (r.mnc <= 0) || (r.area <= 0) || (r.cellId <= 0)
+                				|| (r.mcc == Integer.MAX_VALUE) || (r.mnc == Integer.MAX_VALUE) || (r.area == Integer.MAX_VALUE) || (r.cellId == Integer.MAX_VALUE)) {
                 			Log.i(TAG, String.format("Cell %s has incomplete data, skipping", r.toString()));
                 		} else {
                 			cellsList.add(r);

--- a/src/org/openbmap/unifiedNlp/services/OpenbmapNlpService.java
+++ b/src/org/openbmap/unifiedNlp/services/OpenbmapNlpService.java
@@ -363,50 +363,54 @@ public class OpenbmapNlpService extends LocationBackendService implements ILocat
             }
         }
         
-        List<CellInfo> cellsRawList = mTelephonyManager.getAllCellInfo();
-        if (cellsRawList != null) {
-            Log.d(TAG, "getAllCellInfo found " + cellsRawList.size() + " cells");
-        } else {
-            Log.d(TAG, "getAllCellInfo returned null");
-        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+        	List<CellInfo> cellsRawList = mTelephonyManager.getAllCellInfo();
+        	if (cellsRawList != null) {
+        		Log.d(TAG, "getAllCellInfo found " + cellsRawList.size() + " cells");
+        	} else {
+        		Log.d(TAG, "getAllCellInfo returned null");
+        	}
 
-        if (cellsRawList != null) {
-            for (CellInfo c : cellsRawList) {
-                Cell cell = new Cell();
-                if (c instanceof CellInfoGsm) {
-                    //Log.v(TAG, "GSM cell found");
-                    cell.cellId = ((CellInfoGsm) c).getCellIdentity().getCid();
-                    cell.area = ((CellInfoGsm) c).getCellIdentity().getLac();
-                    cell.mcc = ((CellInfoGsm)c).getCellIdentity().getMcc();
-                    cell.mnc = ((CellInfoGsm)c).getCellIdentity().getMnc();
-                    cell.technology = TECHNOLOGY_MAP().get(mTelephonyManager.getNetworkType());
-                    Log.d(TAG, String.format("CellInfoGsm for %d|%d|%d|%d|%s", cell.mcc, cell.mnc, cell.area, cell.cellId, cell.technology));
-                } else if (c instanceof CellInfoCdma) {
-                    /*
-                    object.put("cellId", ((CellInfoCdma)s).getCellIdentity().getBasestationId());
-                    object.put("locationAreaCode", ((CellInfoCdma)s).getCellIdentity().getLac());
-                    object.put("mobileCountryCode", ((CellInfoCdma)s).getCellIdentity().get());
-                    object.put("mobileNetworkCode", ((CellInfoCdma)s).getCellIdentity().getMnc());*/
-                    Log.wtf(TAG, "Using of CDMA cells for NLP not yet implemented");
-                } else if (c instanceof CellInfoLte) {
-                    //Log.v(TAG, "LTE cell found");
-                    cell.cellId = ((CellInfoLte) c).getCellIdentity().getCi();
-                    cell.area = ((CellInfoLte) c).getCellIdentity().getTac();
-                    cell.mcc = ((CellInfoLte)c).getCellIdentity().getMcc();
-                    cell.mnc = ((CellInfoLte)c).getCellIdentity().getMnc();
-                    cell.technology = TECHNOLOGY_MAP().get(mTelephonyManager.getNetworkType());
-                    Log.d(TAG, String.format("CellInfoLte for %d|%d|%d|%d|%s|%d", cell.mcc, cell.mnc, cell.area, cell.cellId, cell.technology, ((CellInfoLte)c).getCellIdentity().getPci()));
-                } else if (c instanceof CellInfoWcdma) {
-                    //Log.v(TAG, "CellInfoWcdma cell found");
-                    cell.cellId = ((CellInfoWcdma) c).getCellIdentity().getCid();
-                    cell.area = ((CellInfoWcdma) c).getCellIdentity().getLac();
-                    cell.mcc = ((CellInfoWcdma)c).getCellIdentity().getMcc();
-                    cell.mnc = ((CellInfoWcdma)c).getCellIdentity().getMnc();
-                    cell.technology = TECHNOLOGY_MAP().get(mTelephonyManager.getNetworkType());
-                    Log.d(TAG, String.format("CellInfoWcdma for %d|%d|%d|%d|%s|%d", cell.mcc, cell.mnc, cell.area, cell.cellId, cell.technology, ((CellInfoWcdma) c).getCellIdentity().getPsc()));
-                }
-                cells.add(cell);
-            }
+        	if (cellsRawList != null) {
+        		for (CellInfo c : cellsRawList) {
+        			Cell cell = new Cell();
+        			if (c instanceof CellInfoGsm) {
+        				//Log.v(TAG, "GSM cell found");
+        				cell.cellId = ((CellInfoGsm) c).getCellIdentity().getCid();
+        				cell.area = ((CellInfoGsm) c).getCellIdentity().getLac();
+        				cell.mcc = ((CellInfoGsm)c).getCellIdentity().getMcc();
+        				cell.mnc = ((CellInfoGsm)c).getCellIdentity().getMnc();
+        				cell.technology = TECHNOLOGY_MAP().get(mTelephonyManager.getNetworkType());
+        				Log.d(TAG, String.format("CellInfoGsm for %d|%d|%d|%d|%s", cell.mcc, cell.mnc, cell.area, cell.cellId, cell.technology));
+        			} else if (c instanceof CellInfoCdma) {
+        				/*
+        				object.put("cellId", ((CellInfoCdma)s).getCellIdentity().getBasestationId());
+        				object.put("locationAreaCode", ((CellInfoCdma)s).getCellIdentity().getLac());
+        				object.put("mobileCountryCode", ((CellInfoCdma)s).getCellIdentity().get());
+        				object.put("mobileNetworkCode", ((CellInfoCdma)s).getCellIdentity().getMnc());*/
+        				Log.wtf(TAG, "Using of CDMA cells for NLP not yet implemented");
+        			} else if (c instanceof CellInfoLte) {
+        				//Log.v(TAG, "LTE cell found");
+        				cell.cellId = ((CellInfoLte) c).getCellIdentity().getCi();
+        				cell.area = ((CellInfoLte) c).getCellIdentity().getTac();
+        				cell.mcc = ((CellInfoLte)c).getCellIdentity().getMcc();
+        				cell.mnc = ((CellInfoLte)c).getCellIdentity().getMnc();
+        				cell.technology = TECHNOLOGY_MAP().get(mTelephonyManager.getNetworkType());
+        				Log.d(TAG, String.format("CellInfoLte for %d|%d|%d|%d|%s|%d", cell.mcc, cell.mnc, cell.area, cell.cellId, cell.technology, ((CellInfoLte)c).getCellIdentity().getPci()));
+        			} else if (c instanceof CellInfoWcdma) {
+        				//Log.v(TAG, "CellInfoWcdma cell found");
+        				cell.cellId = ((CellInfoWcdma) c).getCellIdentity().getCid();
+        				cell.area = ((CellInfoWcdma) c).getCellIdentity().getLac();
+        				cell.mcc = ((CellInfoWcdma)c).getCellIdentity().getMcc();
+        				cell.mnc = ((CellInfoWcdma)c).getCellIdentity().getMnc();
+        				cell.technology = TECHNOLOGY_MAP().get(mTelephonyManager.getNetworkType());
+        				Log.d(TAG, String.format("CellInfoWcdma for %d|%d|%d|%d|%s|%d", cell.mcc, cell.mnc, cell.area, cell.cellId, cell.technology, ((CellInfoWcdma) c).getCellIdentity().getPsc()));
+        			}
+        			cells.add(cell);
+        		}
+        	}
+    	} else {
+    		Log.d(TAG, "getAllCellInfo is not available (requires API 17)");
         }
         return cells;
     }

--- a/src/org/openbmap/unifiedNlp/services/OpenbmapNlpService.java
+++ b/src/org/openbmap/unifiedNlp/services/OpenbmapNlpService.java
@@ -339,6 +339,7 @@ public class OpenbmapNlpService extends LocationBackendService implements ILocat
                     cell.mcc = mcc;
                     cell.mnc = mnc;
                     cell.technology = TECHNOLOGY_MAP().get(mTelephonyManager.getNetworkType());
+                    Log.d(TAG, String.format("CellInfoGsm for %d|%d|%d|%d|%s", cell.mcc, cell.mnc, cell.area, cell.cellId, cell.technology));
                 } else if (c instanceof CellInfoCdma) {
                     /*
                     object.put("cellId", ((CellInfoCdma)s).getCellIdentity().getBasestationId());
@@ -355,6 +356,7 @@ public class OpenbmapNlpService extends LocationBackendService implements ILocat
                     cell.mcc = mcc;
                     cell.mnc = mnc;
                     cell.technology = TECHNOLOGY_MAP().get(mTelephonyManager.getNetworkType());
+                    Log.d(TAG, String.format("CellInfoLte for %d|%d|%d|%d|%s|%d", cell.mcc, cell.mnc, cell.area, cell.cellId, cell.technology, ((CellInfoLte)c).getCellIdentity().getPci()));
                 } else if (c instanceof CellInfoWcdma) {
                     //Log.v(TAG, "CellInfoWcdma cell found");
                     cell.cellId = ((CellInfoWcdma) c).getCellIdentity().getCid();
@@ -364,6 +366,7 @@ public class OpenbmapNlpService extends LocationBackendService implements ILocat
                     cell.mcc = mcc;
                     cell.mnc = mnc;
                     cell.technology = TECHNOLOGY_MAP().get(mTelephonyManager.getNetworkType());
+                    Log.d(TAG, String.format("CellInfoWcdma for %d|%d|%d|%d|%s|%d", cell.mcc, cell.mnc, cell.area, cell.cellId, cell.technology, ((CellInfoWcdma) c).getCellIdentity().getPsc()));
                 }
                 cells.add(cell);
             }

--- a/src/org/openbmap/unifiedNlp/services/OpenbmapNlpService.java
+++ b/src/org/openbmap/unifiedNlp/services/OpenbmapNlpService.java
@@ -34,6 +34,7 @@ import android.telephony.CellInfoGsm;
 import android.telephony.CellInfoLte;
 import android.telephony.CellInfoWcdma;
 import android.telephony.CellLocation;
+import android.telephony.NeighboringCellInfo;
 import android.telephony.PhoneStateListener;
 import android.telephony.TelephonyManager;
 import android.telephony.cdma.CdmaCellLocation;
@@ -340,6 +341,26 @@ public class OpenbmapNlpService extends LocationBackendService implements ILocat
         		Log.wtf(TAG, "Got a CellLocation of an unknown class");
         } else {
             Log.d(TAG, "getCellLocation returned null");
+        }
+        
+        List<NeighboringCellInfo> neighboringCells = mTelephonyManager.getNeighboringCellInfo();
+        if (neighboringCells != null) {
+            Log.d(TAG, "getNeighboringCellInfo found " + neighboringCells.size() + " cells");
+        } else {
+            Log.d(TAG, "getNeighboringCellInfo returned null");
+        }
+        
+        if (neighboringCells != null) {
+            for (NeighboringCellInfo c : neighboringCells) {
+                Cell cell = new Cell();
+                cell.cellId = c.getCid();
+                cell.area = c.getLac();
+        		cell.mcc = mcc;
+        		cell.mnc = mnc;
+        		cell.technology = TECHNOLOGY_MAP().get(c.getNetworkType());
+                Log.d(TAG, String.format("NeighboringCellInfo for %d|%d|%d|%d|%s|%d", cell.mcc, cell.mnc, cell.area, cell.cellId, cell.technology, c.getPsc()));
+                cells.add(cell);
+            }
         }
         
         List<CellInfo> cellsRawList = mTelephonyManager.getAllCellInfo();

--- a/src/org/openbmap/unifiedNlp/services/OpenbmapNlpService.java
+++ b/src/org/openbmap/unifiedNlp/services/OpenbmapNlpService.java
@@ -335,6 +335,7 @@ public class OpenbmapNlpService extends LocationBackendService implements ILocat
         		cell.mnc = mnc;
         		cell.technology = TECHNOLOGY_MAP().get(mTelephonyManager.getNetworkType());
         		Log.d(TAG, String.format("GsmCellLocation for %d|%d|%d|%d|%s|%d", cell.mcc, cell.mnc, cell.area, cell.cellId, cell.technology, ((GsmCellLocation) cellLocation).getPsc()));
+        		cells.add(cell);
         	} else if (cellLocation instanceof CdmaCellLocation) {
         		Log.w(TAG, "CdmaCellLocation: Using CDMA cells for NLP is not yet implemented");
         	} else

--- a/src/org/openbmap/unifiedNlp/services/OpenbmapNlpService.java
+++ b/src/org/openbmap/unifiedNlp/services/OpenbmapNlpService.java
@@ -356,10 +356,8 @@ public class OpenbmapNlpService extends LocationBackendService implements ILocat
                     //Log.v(TAG, "GSM cell found");
                     cell.cellId = ((CellInfoGsm) c).getCellIdentity().getCid();
                     cell.area = ((CellInfoGsm) c).getCellIdentity().getLac();
-                    //cell.mcc = ((CellInfoGsm)c).getCellIdentity().getMcc();
-                    //cell.mnc = ((CellInfoGsm)c).getCellIdentity().getMnc();
-                    cell.mcc = mcc;
-                    cell.mnc = mnc;
+                    cell.mcc = ((CellInfoGsm)c).getCellIdentity().getMcc();
+                    cell.mnc = ((CellInfoGsm)c).getCellIdentity().getMnc();
                     cell.technology = TECHNOLOGY_MAP().get(mTelephonyManager.getNetworkType());
                     Log.d(TAG, String.format("CellInfoGsm for %d|%d|%d|%d|%s", cell.mcc, cell.mnc, cell.area, cell.cellId, cell.technology));
                 } else if (c instanceof CellInfoCdma) {
@@ -373,20 +371,16 @@ public class OpenbmapNlpService extends LocationBackendService implements ILocat
                     //Log.v(TAG, "LTE cell found");
                     cell.cellId = ((CellInfoLte) c).getCellIdentity().getCi();
                     cell.area = ((CellInfoLte) c).getCellIdentity().getTac();
-                    //cell.mcc = ((CellInfoLte)c).getCellIdentity().getMcc();
-                    //cell.mnc = ((CellInfoLte)c).getCellIdentity().getMnc();
-                    cell.mcc = mcc;
-                    cell.mnc = mnc;
+                    cell.mcc = ((CellInfoLte)c).getCellIdentity().getMcc();
+                    cell.mnc = ((CellInfoLte)c).getCellIdentity().getMnc();
                     cell.technology = TECHNOLOGY_MAP().get(mTelephonyManager.getNetworkType());
                     Log.d(TAG, String.format("CellInfoLte for %d|%d|%d|%d|%s|%d", cell.mcc, cell.mnc, cell.area, cell.cellId, cell.technology, ((CellInfoLte)c).getCellIdentity().getPci()));
                 } else if (c instanceof CellInfoWcdma) {
                     //Log.v(TAG, "CellInfoWcdma cell found");
                     cell.cellId = ((CellInfoWcdma) c).getCellIdentity().getCid();
                     cell.area = ((CellInfoWcdma) c).getCellIdentity().getLac();
-                    //cell.mcc = ((CellInfoWcdma)c).getCellIdentity().getMcc();
-                    //cell.mnc = ((CellInfoWcdma)c).getCellIdentity().getMnc();
-                    cell.mcc = mcc;
-                    cell.mnc = mnc;
+                    cell.mcc = ((CellInfoWcdma)c).getCellIdentity().getMcc();
+                    cell.mnc = ((CellInfoWcdma)c).getCellIdentity().getMnc();
                     cell.technology = TECHNOLOGY_MAP().get(mTelephonyManager.getNetworkType());
                     Log.d(TAG, String.format("CellInfoWcdma for %d|%d|%d|%d|%s|%d", cell.mcc, cell.mnc, cell.area, cell.cellId, cell.technology, ((CellInfoWcdma) c).getCellIdentity().getPsc()));
                 }


### PR DESCRIPTION
Fix a bug preventing geolocation when only cells or only wifis are supplied (cdfc57e)
Fix inconsistencies in range estimates (9b49b60)
Use all available API calls to scan for cells, providing cell-based API lookup on API < 17, fixes #12 (5e90df4, 6593cec, 9edb5e1, e9ad105)
Filter wifis against blacklist to prevent relying on "old" moving wifis, fixes #7 (4ada0f1)
Use MCC/MNC supplied with cell data, where available (2938c7e)
Prevent DB lookup of bogus cells (952f2bc)
Extra debug logging (b6817d2, d499ab0)