### PR TITLE
Fix NPE in MediaScanner

### DIFF
--- a/src/org/radiocells/unifiedNlp/utils/MediaScanner.java
+++ b/src/org/radiocells/unifiedNlp/utils/MediaScanner.java
@@ -49,9 +49,10 @@ public class MediaScanner implements MediaScannerConnectionClient {
     @Override
     public final void onMediaScannerConnected() {
         final File[] files = mFolder.listFiles();
-        for (final File file : files) {
-            mScanner.scanFile(file.getAbsolutePath(), null);
-        }
+        if (files != null)
+            for (final File file : files) {
+                mScanner.scanFile(file.getAbsolutePath(), null);
+            }
     }
 
     @Override


### PR DESCRIPTION
Fixes an NPE if `listFiles()` returns a null array (which can happen if `listFiles()` is called on a folder that is not accessible)