### PR TITLE
WIP: Adapt to API 30

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -11,11 +11,14 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
         android:name="org.radiocells.unifiedNlp.UnifiedNlpApplication"
+        android:requestLegacyExternalStorage="true"
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ android {
     }
     defaultConfig {
         minSdkVersion 18
-        targetSdkVersion 29
+        targetSdkVersion 30
     }
 }
 

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -4,7 +4,7 @@
         Base application theme, dependent on API level. This theme is replaced
         by AppBaseTheme from res/values-vXX/styles.xml on newer devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.DeviceDefault">
+    <style name="AppBaseTheme" parent="Theme.AppCompat">
         <!--
             Theme customizations available in newer API levels can go in
             res/values-vXX/styles.xml, while customizations related to

--- a/src/org/radiocells/unifiedNlp/UnifiedNlpApplication.java
+++ b/src/org/radiocells/unifiedNlp/UnifiedNlpApplication.java
@@ -12,12 +12,20 @@ public class UnifiedNlpApplication extends Application implements ActivityCompat
 
     @Override
     public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
-        boolean isGranted = false;
+        boolean isLocationGranted = false;
+        boolean isPhoneStateGranted = false;
         for (int i = 0; i < grantResults.length; i++)
-            if (permissions[i].equals(Manifest.permission.ACCESS_FINE_LOCATION) && (grantResults[i] == PackageManager.PERMISSION_GRANTED))
-                isGranted = true;
-        if (!isGranted) {
+            if (grantResults[i] == PackageManager.PERMISSION_GRANTED) {
+                if (permissions[i].equals(Manifest.permission.ACCESS_FINE_LOCATION))
+                    isLocationGranted = true;
+                else if (permissions[i].equals(Manifest.permission.READ_PHONE_STATE))
+                isPhoneStateGranted = true;
+            }
+        if (!isLocationGranted) {
             Log.w(TAG, "ACCESS_FINE_LOCATION permission not granted");
+        }
+        if (!isPhoneStateGranted) {
+            Log.w(TAG, "READ_PHONE_STATE permission not granted");
         }
     }
 

--- a/src/org/radiocells/unifiedNlp/UnifiedNlpApplication.java
+++ b/src/org/radiocells/unifiedNlp/UnifiedNlpApplication.java
@@ -16,7 +16,9 @@ public class UnifiedNlpApplication extends Application implements ActivityCompat
         boolean isPhoneStateGranted = false;
         for (int i = 0; i < grantResults.length; i++)
             if (grantResults[i] == PackageManager.PERMISSION_GRANTED) {
-                if (permissions[i].equals(Manifest.permission.ACCESS_FINE_LOCATION))
+                if (permissions[i].equals(Manifest.permission.ACCESS_FINE_LOCATION) && (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.Q))
+                    isLocationGranted = true;
+                else if (permissions[i].equals(Manifest.permission.ACCESS_BACKGROUND_LOCATION) && (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q))
                     isLocationGranted = true;
                 else if (permissions[i].equals(Manifest.permission.READ_PHONE_STATE))
                 isPhoneStateGranted = true;

--- a/src/org/radiocells/unifiedNlp/services/RadiocellsLocationService.java
+++ b/src/org/radiocells/unifiedNlp/services/RadiocellsLocationService.java
@@ -58,6 +58,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -208,16 +209,29 @@ public class RadiocellsLocationService extends LocationBackendService implements
     protected Location update() {
         Calendar now = Calendar.getInstance();
 
+        HashSet<String> missingPerms = new HashSet<String>();
+
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
             Log.d(TAG, "Fine location access available");
         } else {
             Log.i(TAG, "Missing fine location access - requesting");
+            missingPerms.add(Manifest.permission.ACCESS_FINE_LOCATION);
+        }
+
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED) {
+            Log.d(TAG, "Read phone state permission available");
+        } else {
+            Log.i(TAG, "Missing phone state read access - requesting");
+            missingPerms.add(Manifest.permission.READ_PHONE_STATE);
+        }
+
+        if (!missingPerms.isEmpty()){
             PermissionHelper.requestPermissions(
                     (UnifiedNlpApplication) (getApplicationContext()),
-                    new String[]{Manifest.permission.ACCESS_FINE_LOCATION},
+                    missingPerms.toArray(new String[] {}),
                     1212,
                     "Permission needed",
-                    "Location access is needed for radiocells.org UnifiedNLP backend",
+                    "Permissions are needed for radiocells.org UnifiedNLP backend",
                     R.drawable.ic_launcher);
             return null;
         }
@@ -274,7 +288,7 @@ public class RadiocellsLocationService extends LocationBackendService implements
             Log.d(TAG, "Scanning cells only");
             getLocationFromWifisAndCells(null);
         } else {
-            Log.e(TAG, "Neigther cells nor wifis as source selected? Com'on..");
+            Log.e(TAG, "Neither cells nor wifis as source selected? Com'on..");
         }
 
         return null;

--- a/src/org/radiocells/unifiedNlp/services/RadiocellsLocationService.java
+++ b/src/org/radiocells/unifiedNlp/services/RadiocellsLocationService.java
@@ -213,6 +213,17 @@ public class RadiocellsLocationService extends LocationBackendService implements
 
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
             Log.d(TAG, "Fine location access available");
+            /*
+             * We need both permissions, but we cannot request them together (if we do, Android 11+ will deny the request).
+             */
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_BACKGROUND_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+                    Log.d(TAG, "Background location access available");
+                } else {
+                    Log.i(TAG, "Missing background location access - requesting");
+                    missingPerms.add(Manifest.permission.ACCESS_BACKGROUND_LOCATION);
+                }
+            }
         } else {
             Log.i(TAG, "Missing fine location access - requesting");
             missingPerms.add(Manifest.permission.ACCESS_FINE_LOCATION);

--- a/src/org/radiocells/unifiedNlp/utils/PermissionHelper.java
+++ b/src/org/radiocells/unifiedNlp/utils/PermissionHelper.java
@@ -135,10 +135,12 @@ public class PermissionHelper {
          */
         @Override
         public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
-            Bundle resultData = new Bundle();
-            resultData.putStringArray("permissions", permissions);
-            resultData.putIntArray("grantResults", grantResults);
-            resultReceiver.send(requestCode, resultData);
+            if (resultReceiver != null) {
+                Bundle resultData = new Bundle();
+                resultData.putStringArray("permissions", permissions);
+                resultData.putIntArray("grantResults", grantResults);
+                resultReceiver.send(requestCode, resultData);
+            }
             finish();
         }
 


### PR DESCRIPTION
**Work in progress, do not merge until this notice is removed**

This adapts the location provider to work with API 30:

* Request background location access when running on API 29+ (Android 10+)
* Request `READ_PHONE_STATE` (required for `getNetworkType()`, else a security exception will be thrown)
* Request full file access on API 29/30+ (currently needs to be granted manually in system preferences, interactive permission request not yet implemented)
* TBD: Deal with WiFi scan limits for background services